### PR TITLE
Detect user's locale for default option

### DIFF
--- a/src/Fields/CountryDropdownField.php
+++ b/src/Fields/CountryDropdownField.php
@@ -15,10 +15,10 @@ use SilverStripe\i18n\Data\Intl\IntlLocales;
 class CountryDropdownField extends DropdownField
 {
     /**
-     * @var 
+     * @var
      */
     private $countries;
-    
+
     /**
      * @var array
      */
@@ -82,11 +82,11 @@ class CountryDropdownField extends DropdownField
     }
 
     /**
-     * @return array
+     * @return array Map of country code => name
      */
     protected function getDefaultCountriesList()
     {
-        return IntlLocales::singleton()->config()->get('countries');
+        return IntlLocales::singleton()->getCountries();
     }
 
     /**

--- a/tests/CountryDropdownTest.php
+++ b/tests/CountryDropdownTest.php
@@ -13,7 +13,7 @@ use SilverStripe\i18n\Data\Intl\IntlLocales;
 class CountryDropdownTest extends SapphireTest
 {
     /**
-     * 
+     *
      */
     public function testSetCountries()
     {
@@ -30,17 +30,17 @@ class CountryDropdownTest extends SapphireTest
     }
 
     /**
-     * 
+     *
      */
     public function testGetDefaultCountriesList()
     {
         $field = CountryDropdownField::create('Country');
 
-        $this->assertEquals(IntlLocales::singleton()->config()->get('countries'), $field->getCountries());
+        $this->assertEquals(IntlLocales::singleton()->getCountries(), $field->getCountries());
     }
 
     /**
-     * 
+     *
      */
     public function testSetSource()
     {
@@ -53,11 +53,11 @@ class CountryDropdownTest extends SapphireTest
     }
 
     /**
-     * 
+     *
      */
     public function testGetSource()
     {
-        $default = IntlLocales::singleton()->config()->get('countries');
+        $default = IntlLocales::singleton()->getCountries();
         $newSource = ['fo' => 'Foo'];
 
         $field = CountryDropdownField::create('Country');
@@ -70,7 +70,7 @@ class CountryDropdownTest extends SapphireTest
     }
 
     /**
-     * 
+     *
      */
     public function testSetDisabledItems()
     {


### PR DESCRIPTION
Switching from
config()->get('countries')
to getCountries() respects the user's locale.
It delivers a map containing both the locale code and name where the latter is used in the frontend while the code is stored to the database.