### PR TITLE
Replace CMS requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "type": "silverstripe-vendormodule",
   "license": "BSD-3-Clause",
   "require": {
-    "silverstripe/recipe-cms": "^1.0 || ^4.0",
+    "silverstripe/recipe-framework": "^4.0",
     "silverstripe/vendor-plugin": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "type": "silverstripe-vendormodule",
   "license": "BSD-3-Clause",
   "require": {
-    "silverstripe/recipe-framework": "^4.0",
+    "silverstripe/framework": "^4.0",
     "silverstripe/vendor-plugin": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
Replace the `recipe-cms` requirement because this module can be installed in a headless/framework only project.

Also can't be installed if a `recipe-cms` project is inlined (https://github.com/silverstripe/recipe-plugin#inlining-recipes)