### PR TITLE
Upgrade to SilverStripe 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0.x-dev"
+            "dev-master": "3.x-dev"
         },
         "project-files-installed": [
             ".htaccess",

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,11 @@
         }
     ],
     "require": {
-        "silverstripe/recipe-core": "^5.0"
+        "php": "^8.1",
+        "silverstripe/recipe-core": "^6"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3"
+        "silverstripe/recipe-testing": "^4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -47,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev"
+            "dev-master": "3.0.x-dev"
         },
         "project-files-installed": [
             ".htaccess",


### PR DESCRIPTION
Upgrades the module to SilverStripe 6 compatibility.

## Changes

- Added PHP requirement ^8.1
- Updated `silverstripe/recipe-core` from ^5 to ^6
- Updated `silverstripe/recipe-testing` from ^3 to ^4
- Updated branch-alias to `3.0.x-dev`

## Testing

- ✅ PHPCS: Clean
- ✅ No code changes required (form field only)

This prepares the module for the 3.0.0 release and resolves the dependency blocker for `dynamic/silverstripe-geocoder` SS6 upgrade.