### PR TITLE
fix: Update PHP requirement to ^8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "silverstripe/recipe-core": "^6"
     },
     "require-dev": {


### PR DESCRIPTION
Updates the PHP requirement from ^8.1 to ^8.3 to align with SilverStripe 6 framework requirements.

## Changes

- Updated PHP requirement to ^8.3 in composer.json

## Reason

SilverStripe 6 requires PHP ^8.3 as its minimum version. This was initially set to ^8.1 during the SS6 upgrade but needs to match the framework's actual requirements.

Reference: https://github.com/silverstripe/silverstripe-framework/blob/6/composer.json

This prepares the module for a v3.0.1 patch release.